### PR TITLE
Upgrade documentation; increase KB build timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,36 +17,72 @@ You can learn more about it by asking the assistant: "What's NIKA?"
 
 
 ## Requirements
-You will need [Docker](https://docs.docker.com/get-docker/) installed and running on your machine.
+You will need [Docker](https://docs.docker.com/) (with Compose plugin) installed and running on your machine. 
+
+We recommend using Docker Desktop on [macOS](https://docs.docker.com/desktop/install/mac-install/) / [Windows](https://docs.docker.com/desktop/install/windows-install/) and using [Docker Server](https://docs.docker.com/engine/install/#server) distribution for your Linux distribution of choice. Use installation instructions provided in the links above.
 ## Installation
 
 ```sh
-git clone --recursive https://github.com/ostis-apps/nika
+git clone -c core.longpaths=true -c core.autocrlf=true https://github.com/ostis-apps/nika
+git submodule update --init --recursive
 cd nika
 docker compose pull
 ```
 
 ## 🚀 Usage
-```sh
-cd nika
-docker compose up
-```
-This command will launch 2 Web UIs on your machine: 
-- sc-web - `localhost:8000`
-- dialogue web UI - `localhost:3033`
+- Launch
+  ```sh
+  docker compose up --no-build
+  ```
+    This command will launch 2 Web UIs on your machine: 
+  - sc-web - `localhost:8000`
+  - dialogue web UI - `localhost:3033`
 
+We've set our system to rebuild KB on each restart. If you're debugging some specific subset of your knowledge base you may want to change repo.path to exclude the folders you don't need. 
+
+If you do not want to rebuild KB on relaunch, you can comment out the `REBUILD_KB` environment variable in `docker-compose.yml`
 ## Author
 
 * Website: [sem.systems](https://sem.systems/)
-* Github: [@ostis-apps](https://github.com/ostis-apps), [@ostis-ai](https://github.com/ostis-ai)
+* GitHub: [@ostis-apps](https://github.com/ostis-apps), [@ostis-ai](https://github.com/ostis-ai)
+
+## Show your support
+
+Give us a ⭐️ if you've liked this project!
+
+## Troubleshooting
+Windows-specific problems:
+- Docker images built on your computer are not launching correctly and logging something along these lines: `bash\r: No such file or directory`
+  
+  **Solution**: please make sure your Git repo is configured to be compatible UNIX line endings
+  ```sh
+  cd nika
+  git config --local core.autocrlf true
+  ```
+- Git cannot clone repos or submodules, error looks like `error: unable to create file ... (file too long)`
+
+  **Solution**: please make sure your Git repo has `longpaths` config option enabled:
+  ```sh
+  cd nika
+  git config --local core.longpaths true
+  ```
+Common issues:
+- Docker images cannot be built locally. Error: `status: the --mount option requires BuildKit` 
+  
+  **Solution**: Please note that you'd only need it for custom images, you can launch our system without building images yourself. Use the [Docker Docs BuildKit reference](https://docs.docker.com/go/buildkit) to enable Docker BuildKit on your computer. **In case you're using Windows**, you could use `$env:DOCKER_BUILDKIT = 1` while building in PowerShell.
+
+- Help! My problem-solver container is `unhealthy`
+  
+  Looks like your container didn't start properly. There are two main reasons for this: violated `start_period` (in case it naturally takes a lot of time to launch our system on your hardware) or faulty server instance. Since there are 2 reasons to this problem, we'll provide 2 solutions. 
+  
+  **Solution 1**: Increasing `start_period` in `docker-compose.yml` might help you.
+
+  **Solution 2**: Check [known issues](https://github.com/ostis-apps/nika/issues), and in case your problem is not reported yet, create a new one! 
+
 
 ## 🤝 Contributing
 
 Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/ostis-apps/nika/issues). 
-
-## Show your support
-
-Give a ⭐️ if you've liked this project!
 
 ## 📝 License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ./sc-web
       dockerfile: ./Dockerfile
+    container_name: nika-sc-web
     restart: unless-stopped
     ports:
       - "8000:8000"
@@ -22,6 +23,7 @@ services:
     build:
       context: ./
       dockerfile: ./Dockerfile
+    container_name: nika-problem-solver
     restart: unless-stopped
     volumes:
       - ./kb:/nika/kb
@@ -39,7 +41,7 @@ services:
       interval: 5s
       timeout: 10s
       retries: 6
-      start_period: 40s
+      start_period: 120s
     environment:
       # Use the commented env variable if you need to rebuild KB every startup.
       - "REBUILD_KB=1"
@@ -52,8 +54,9 @@ services:
     build:
       context: ./interface
       dockerfile: ./Dockerfile
+    container_name: nika-ui
     restart: unless-stopped
-    ports: 
+    ports:
       - "3033:8080"
     networks:
       - nika


### PR DESCRIPTION
Changes made in the PR:
1. Troubleshooting section in the README.md. It should be moved to `docs/`, but since we aren't hosting mkdocs on GitHub Pages, we can temporarily place it inside README.md
2. Enhanced installation instructions. It will help users avoid some common issues (mostly people using M$ Windows) 
3. Increased `start_period` timeout for the problem solver. Fixes #5.