### PR TITLE
KB smol updates)

### DIFF
--- a/kb/extra/nrel_note.scs
+++ b/kb/extra/nrel_note.scs
@@ -1,0 +1,12 @@
+nrel_note
+=> nrel_main_idtf:
+    [примечание*]
+    (* <- lang_ru;; *);
+    [note*]
+    (* <- lang_en;; *);
+<- relation;
+<- binary_relation;
+<- oriented_relation;
+<- antireflexive_relation;
+<- asymmetric_relation;
+<- antitransitive_relation;;

--- a/kb/section_subject_domain_of_dialogues/section_subject_domain_of_dialog_control/section_subject_domain_of_dialogue_control_using_template_responses/concepts/concept_answer_on_standard_message_rule_class_by_priority.scs
+++ b/kb/section_subject_domain_of_dialogues/section_subject_domain_of_dialog_control/section_subject_domain_of_dialogue_control_using_template_responses/concepts/concept_answer_on_standard_message_rule_class_by_priority.scs
@@ -4,6 +4,21 @@ concept_answer_on_standard_message_rule_class_by_priority
         [set of rules for responding to standard messages] (* <- lang_en;; *);
     <- sc_node_class;;
 
+concept_answer_on_standard_message_rule_priority_1
+	=> nrel_main_idtf:
+        [множество правил ответов на стандартные сообщения первого приоритета] (* <- lang_ru;; *);
+        [set of rules for responding to standard messages the first priority] (* <- lang_en;; *);;
+
+concept_answer_on_standard_message_rule_priority_2
+	=> nrel_main_idtf:
+        [множество правил ответов на стандартные сообщения второго приоритета] (* <- lang_ru;; *);
+        [set of rules for responding to standard messages the second priority] (* <- lang_en;; *);;
+
+concept_answer_on_standard_message_rule_priority_3
+	=> nrel_main_idtf:
+        [множество правил ответов на стандартные сообщения третьего приоритета] (* <- lang_ru;; *);
+        [set of rules for responding to standard messages the third priority] (* <- lang_en;; *);;
+
 @access_arc_1 = (concept_answer_on_standard_message_rule_class_by_priority -> rrel_1: concept_answer_on_standard_message_rule_priority_1);;
 @access_arc_2 = (concept_answer_on_standard_message_rule_class_by_priority -> concept_answer_on_standard_message_rule_priority_2);;
 @access_arc_3 = (concept_answer_on_standard_message_rule_class_by_priority -> concept_answer_on_standard_message_rule_priority_3);;

--- a/kb/section_subject_domain_of_dialogues/section_subject_domain_of_dialog_control/section_subject_domain_of_dialogue_control_using_template_responses/concepts/concept_classify_message_rule.scs
+++ b/kb/section_subject_domain_of_dialogues/section_subject_domain_of_dialog_control/section_subject_domain_of_dialogue_control_using_template_responses/concepts/concept_classify_message_rule.scs
@@ -4,6 +4,21 @@ concept_classify_message_rule
         [set of rules for classification messages] (* <- lang_en;; *);
     <- sc_node_class;;
 
+concept_classify_message_rule_priority_1
+	=> nrel_main_idtf:
+        [множество правил классификации сообщения первого приоритета] (* <- lang_ru;; *);
+        [set of rules for classification messages the first priority] (* <- lang_en;; *);;
+
+concept_classify_message_rule_priority_2
+	=> nrel_main_idtf:
+        [множество правил классификации сообщения второго приоритета] (* <- lang_ru;; *);
+        [set of rules for classification messages the second priority] (* <- lang_en;; *);;
+
+concept_classify_message_rule_priority_3
+	=> nrel_main_idtf:
+        [ммножество правил классификации сообщения третьего приоритета] (* <- lang_ru;; *);
+        [set of rules for classification messages the third priority] (* <- lang_en;; *);;
+
 @access_arc_1 = (concept_classify_message_rule -> rrel_1: concept_classify_message_rule_priority_1);;
 @access_arc_2 = (concept_classify_message_rule -> concept_classify_message_rule_priority_2);;
 @access_arc_3 = (concept_classify_message_rule -> concept_classify_message_rule_priority_3);;

--- a/kb/section_subject_domain_of_messages/relations/nrel_phrase_template.scs
+++ b/kb/section_subject_domain_of_messages/relations/nrel_phrase_template.scs
@@ -1,0 +1,47 @@
+nrel_phrase_template
+<- sc_node_norole_relation;
+<- relation;
+<- binary_relation;
+<- oriented_relation;
+<- antireflexive_relation;
+<- antitransitive_relation;
+<- asymmetric_relation;
+=> nrel_main_idtf:
+	[шаблон фразы*]
+	(* <- lang_ru;; *);
+	[phrase template*]
+	(* <- lang_en;; *);
+=> nrel_first_domain: concept_phrase;
+=> nrel_second_domain: atomic_logical_formula;
+=> nrel_definitional_domain:
+        ...
+        (*
+            <= nrel_combination:
+                {
+                    concept_phrase;
+                    atomic_logical_formula
+                };;
+        *);
+<- rrel_key_sc_element:
+	...
+	(*
+	=> nrel_main_idtf:
+		[Опр. (шаблон фразы*)]
+		(* <- lang_ru;; *);
+		[Def. (phrase template*)]
+		(* <- lang_en;; *);;
+	<- definition;;
+	<= nrel_sc_text_translation:
+		...
+		(*
+		-> rrel_example:
+			[шаблон фразы* - бинарное ориентированное отношение, связывающее фразу с шаблоном для её формирования, используя конструкции из базы знаний.]
+			(* <- lang_ru;; *);;
+		*);
+		...
+		(*
+		-> rrel_example: 
+			[phrase template* is a binary oriented relationship, that connects a phrase with a template to form a phrase using knowledge base constructions.]
+			(* <- lang_en;; *);;
+		*);;
+	*);;


### PR DESCRIPTION
Need to display **nrel_note** relation in scg and scn, no need to see flying relation. 
Also add main identifiers to rules set