### PR TITLE
Fix/push-py-sc-server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,32 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=ostis/nika-ui:buildcache
           cache-to: type=registry,ref=ostis/nika-ui:buildcache,mode=max
+
+  py_agents_docker:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: ./problem-solver/py/Dockerfile
+          push: true
+          tags: ostis/nika-py-agents:latest,ostis/nika-py-agents:${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=ostis/nika-py-agents:buildcache
+          cache-to: type=registry,ref=ostis/nika-py-agents:buildcache,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./kb:/nika/kb
-      - kb-binary:/kb.bin
+      - kb-binary:/nika/kb.bin
       - ./repo.path:/nika/repo.path
       - ./nika.ini:/nika/nika.ini
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
     environment:
       # Use the commented env variable if you need to rebuild KB every startup.
       - "REBUILD_KB=1"
-      - "ROOT_CMAKE_PATH=/patient-care"
       - "BINARY_PATH=/nika/bin"
       - "BUILD_PATH=/nika/build"
       - "CONFIG_PATH=/nika/nika.ini"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - web
 
   py-sc-server:
+    image: ostis/nika-py-agents:0.1.0
     build:
       context: ./
       dockerfile: ./problem-solver/py/Dockerfile


### PR DESCRIPTION
This PR will address #292. We still have to work on developer experience for python agents because currently there is no hot-reload mechanism for Python code inside this image. py-sc-server codebase should probably be shared between OSTIS systems anyway, so it's a temporary workaround